### PR TITLE
Fix NameError in Django Ninja API by renaming _request parameter

### DIFF
--- a/app/webapp/api.py
+++ b/app/webapp/api.py
@@ -7,5 +7,5 @@ api = NinjaAPI(
 
 
 @api.get("/add")
-def add(_request, a: int, b: int):
+def add(request, a: int, b: int):
     return {"result": a + b}


### PR DESCRIPTION
## Summary
- Fixed CI build failure caused by NameError in Django Ninja API
- Renamed `_request` to `request` in webapp/api.py
- Pydantic doesn't allow field names with leading underscores

## Test plan
- [x] Verified Django checks pass locally
- [x] No other code changes needed

🤖 Generated with [Claude Code](https://claude.ai/code)