### PR TITLE
Fix production Docker build by removing CSS compilation step

### DIFF
--- a/dockerfiles/app.Dockerfile
+++ b/dockerfiles/app.Dockerfile
@@ -9,15 +9,8 @@ RUN apt update && apt-get install -y libmagic1 \
 # for psycopg2 build - because we are using different architectures, this must be built from source
 # instead of psycopg2-binary
 libpq-dev \
-build-essential \
-curl
+build-essential
 WORKDIR /src
 RUN uv sync
-# Build CSS for production
-RUN if [ "$ENVIRONMENT" = "production" ]; then \
-    curl -sLO https://github.com/tailwindlabs/tailwindcss/releases/latest/download/tailwindcss-linux-x64 && \
-    chmod +x tailwindcss-linux-x64 && \
-    cd app && \
-    ../tailwindcss-linux-x64 -i input.css -o ../static/output.css; \
-fi
+# CSS is pre-built and included in static/output.css
 CMD /bin/bash -c "./app_startup/${ENVIRONMENT}.sh"


### PR DESCRIPTION
## Summary
- Remove failing Tailwind CLI download and build step from production Dockerfile
- Simplify deployment by using pre-built CSS file committed to repository
- Fix Docker build failure that was causing deployment issues

## Problem
The production Docker build was failing with exit code 127 when trying to download and execute the Tailwind CLI binary. This was blocking deployments after the CSS migration from CDN to local files.

## Solution
- Remove the CSS compilation step from the Dockerfile entirely
- Use the pre-built `static/output.css` file that's already committed to the repository
- CSS can still be rebuilt locally using the Docker Compose CSS service when needed

## Test plan
- [x] Docker build completes successfully without CSS compilation step
- [ ] Production deployment succeeds
- [ ] Site renders with proper styling using pre-built CSS
- [ ] Local development CSS rebuild still works via Docker Compose

🤖 Generated with [Claude Code](https://claude.ai/code)