### PR TITLE
Fix HTMX static assets missing in production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,12 +109,30 @@ jobs:
           echo "Static files verified:"
           ls -la static/output.css static/libraries/main.js
 
-      - name: Upload static files to S3
+      - name: Setup Python for Django collectstatic
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python dependencies
         run: |
-          aws s3 sync static/ s3://static-opensailor-org/static/ \
-            --cache-control "max-age=31536000, public" \
-            --exclude "*.DS_Store" \
-            --delete
+          pip install uv
+          cd app
+          uv sync
+
+      - name: Collect and upload all static files to S3
+        run: |
+          cd app
+          uv run python manage.py collectstatic --noinput
+        env:
+          # Django settings
+          ENVIRONMENT: production
+          DJANGO_SECRET_KEY: ${{ secrets.DJANGO_SECRET_KEY }}
+          # S3 configuration
+          AWS_S3_STORAGE_BUCKET: static-opensailor-org
+          AWS_DEFAULT_REGION_NAME: ${{ vars.AWS_REGION }}
+          AWS_S3_ENDPOINT_URL: https://s3.${{ vars.AWS_REGION }}.amazonaws.com
+          AWS_S3_CLIENT_ENDPOINT_URL: https://static.opensailor.org
 
       - name: Build and push image to Amazon ECR
         id: build-image


### PR DESCRIPTION
- Add Django collectstatic to CI deployment pipeline
- Setup Python environment in GitHub Actions
- Run collectstatic to gather all Django package static files (including django-htmx)
- Upload all static files to S3 using Django's storage backend
- Remove manual aws s3 sync in favor of Django's collectstatic

This ensures HTMX.js and other Django package assets are available in production.

🤖 Generated with [Claude Code](https://claude.ai/code)